### PR TITLE
fix for aws provider version upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,12 @@ resource "aws_dynamodb_table" "terraform_lock" {
 # S3 bucket for storing terraform state
 resource "aws_s3_bucket" "terraform_state" {
   bucket = var.bucket_name
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
 }


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#versioning-argument

To make the module compatible with the aws provider >= v4.0